### PR TITLE
Make background color-setting optional

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -6,6 +6,7 @@ typedef struct {
   int bgColor;
   int frameRate;
   bool bigFont;
+  bool useColor;
 } configuration_t;
 // configuration_t config = {.fgColor = 0, .bgColor = 7, .frameRate = 20};
 // extern configuration_t config;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,13 +33,14 @@ int main(int argc, char **argv) {
   configuration_t config = {
       .fgColor = 7, .bgColor = 0, .frameRate = 20, .bigFont = FALSE};
   int c;
-  while ((c = getopt(argc, argv, "hbC:B:F:")) != -1) {
+  while ((c = getopt(argc, argv, "hbcC:B:F:")) != -1) {
     switch (c) {
     case 'h':
     default:
       printf(
           "usage : tty-pong-clock [-b] [-B [0-7] -C [0-7] -F [1-60] ]          "
           "  \n"
+          "    -c            Enable curses setting back/foreground colors   \n"
           "    -C            Set forground color                            \n"
           "    -B            Set background color                           \n"
           "    -F            Set frame rate default 30 fps                  \n"
@@ -48,12 +49,16 @@ int main(int argc, char **argv) {
       exit(EXIT_SUCCESS);
       break;
     case 'C':
-      if (atoi(optarg) >= 0 && atoi(optarg) < 8)
+      if (atoi(optarg) >= 0 && atoi(optarg) < 8) {
+        config.useColor = TRUE;
         config.fgColor = atoi(optarg);
+      }
       break;
     case 'B':
-      if (atoi(optarg) >= 0 && atoi(optarg) < 8)
+      if (atoi(optarg) >= 0 && atoi(optarg) < 8) {
+        config.useColor = TRUE;
         config.bgColor = atoi(optarg);
+      }
       break;
     case 'F':
       if (atoi(optarg) >= 1 && atoi(optarg) <= 60)
@@ -61,6 +66,9 @@ int main(int argc, char **argv) {
       break;
     case 'b':
       config.bigFont = TRUE;
+      break;
+    case 'c':
+      config.useColor = TRUE;
       break;
     }
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char **argv) {
     case 'h':
     default:
       printf(
-          "usage : tty-pong-clock [-b] [-B [0-7] -C [0-7] -F [1-60] ]          "
+          "usage : tty-pong-clock [-b] [-c] [-B [0-7] -C [0-7] -F [1-60] ]          "
           "  \n"
           "    -c            Enable curses setting back/foreground colors   \n"
           "    -C            Set forground color (implies -c)               \n"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,8 +41,8 @@ int main(int argc, char **argv) {
           "usage : tty-pong-clock [-b] [-B [0-7] -C [0-7] -F [1-60] ]          "
           "  \n"
           "    -c            Enable curses setting back/foreground colors   \n"
-          "    -C            Set forground color                            \n"
-          "    -B            Set background color                           \n"
+          "    -C            Set forground color (implies -c)               \n"
+          "    -B            Set background color (implies -c)              \n"
           "    -F            Set frame rate default 30 fps                  \n"
           "    -b            Set big font                                     "
           "\n");

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -21,8 +21,15 @@ Matrix::Matrix(configuration_t &config) {
     keypad(stdscr, TRUE); /* We get F1, F2 etc..		*/
     curs_set(0);
     timeout(1000 / config.frameRate); // 30fps
-    start_color();
-    init_pair(1, config.fgColor, config.bgColor);
+    /*
+    * If you set a custom background, curses changes it to black
+    * This makes it optional.
+    */
+    if (config.useColor) {
+      start_color();
+      init_pair(1, config.fgColor, config.bgColor);
+    }
+    
     attron(COLOR_PAIR(1));
     getmaxyx(stdscr, _heigth, _width);
     _heigth = _heigth * 2;


### PR DESCRIPTION
This patch makes having NCurses reset the background optional.
On a shell with a custom background, curses forces it to black, giving this garbage:
(invoked with `build/tty-pong-clock -bF240` without the patch)
![image](https://user-images.githubusercontent.com/50145141/109370420-d37ac300-7865-11eb-8414-ac4316e02044.png)
This patch adds an option, `-c` to _enable_ setting these colors, and leaves it to the terminal to have sane defaults.
This screenshot was taken with the patch, and the same options as before:
![image](https://user-images.githubusercontent.com/50145141/109370429-dbd2fe00-7865-11eb-85e4-2c0bb0ad9da5.png)
Note that using `-C` or `-B` implies `-c` and causes `config.useColor` to be set.
