### PR TITLE
Make program exit if the given arguments are not in range

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,17 +51,27 @@ int main(int argc, char **argv) {
       if (atoi(optarg) >= 0 && atoi(optarg) < 8) {
         config.useColor = TRUE;
         config.fgColor = atoi(optarg);
+      } else {
+        printf("tty-pong-clock: %d is not a valid value for -C\n", atoi(optarg));
+        exit(EXIT_FAILURE);
       }
       break;
     case 'B':
       if (atoi(optarg) >= 0 && atoi(optarg) < 8) {
         config.useColor = TRUE;
         config.bgColor = atoi(optarg);
+      } else {
+        printf("tty-pong-clock: %d is not a valid value for -B\n", atoi(optarg));
+        exit(EXIT_FAILURE);
       }
       break;
     case 'F':
-      if (atoi(optarg) >= 1 && atoi(optarg) <= 60)
+      if (atoi(optarg) >= 1 && atoi(optarg) <= 60) {
         config.frameRate = atoi(optarg);
+      } else {
+        printf("tty-pong-clock: %d if not a valid value for -F\n", atoi(optarg));
+        exit(EXIT_FAILURE);
+      }
       break;
     case 'b':
       config.bigFont = TRUE;


### PR DESCRIPTION
Right now, when you give an argument over the allowed range (`tty-pong-clock -F83701532`, for example), it uses the default —silently—, which is not cool.
This adds an error message to options `-B`, `-C` and `-F`.
